### PR TITLE
Adding Logz.io Fields to Prospector Configs

### DIFF
--- a/discoverer/kubernetes/common/builder/log_annotations/log_annotations_test.go
+++ b/discoverer/kubernetes/common/builder/log_annotations/log_annotations_test.go
@@ -43,6 +43,21 @@ func TestLogAnnotationBuilder(t *testing.T) {
 			},
 			length: 2,
 		},
+		{
+			annotations: map[string]interface{}{
+				"foo/logzCodec": "json",
+				"foo/logzEnv":   "prod",
+			},
+			length: 2,
+		},
+		{
+			annotations: map[string]interface{}{
+				"foo/pattern":   "bar",
+				"foo/logzCodec": "json",
+				"foo/logzEnv":   "prod",
+			},
+			length: 2,
+		},
 	}
 
 	for _, test := range tests {
@@ -140,4 +155,19 @@ func TestProspectorConfig(t *testing.T) {
 	assert.Equal(t, confs[1].Config["paths"], []string{"/var/456/*.log"})
 	assert.Equal(t, confs[1].Config["multiline"], multilineCfg["multiline"])
 
+	logzCfg := common.MapStr{}
+	logzExpectedCfg := common.MapStr{
+		"logzToken": "ABC123",
+		"logzCodec": "json",
+		"logzEnv":   "prod",
+	}
+	setLogzFields("ABC123", "json", "prod", logzCfg)
+	assert.Equal(t, logzExpectedCfg, logzCfg["fields"])
+
+	logzCfg["fields"] = common.MapStr{
+		"namespace": "abc",
+	}
+	logzExpectedCfg["namespace"] = "abc"
+	setLogzFields("ABC123", "json", "prod", logzCfg)
+	assert.Equal(t, logzExpectedCfg, logzCfg["fields"])
 }


### PR DESCRIPTION
Adds in the required logz.io fields into the generated prospector config files in Collectbeat. It builds, but still needs to be fully tested.

### Configuring Collectbeat for Logz.io
Add the following annotations to your pod for logz.io: 
```
io.collectbeat.logs/logzCodec: plain|json
io.collectbeat.logs/env: desired_environment
```
You can also pass the logz.io token in as an annotation or as a environment variable (which allows the use of Kubernetes secrets).
```
# Annotation
io.collectbeat.logs/logzToken: logz_token

# Kube Secret, add to collectbeat manifest
# example (assuming secret already exists):
    env:
      - name: LOGZ_TOKEN
        valueFrom:
          secretKeyRef:
            name: env_logz_token
            key: token 
```


